### PR TITLE
Correciones gr4j rev

### DIFF
--- a/src/pydrodelta/pydrology.py
+++ b/src/pydrodelta/pydrology.py
@@ -719,9 +719,10 @@ class GR4J:
         self.routStore=RoutingStoreGR4J(pars=[self.routStoreMaxStorage,self.waterExchange],Boundaries=self.channel1.Outflow,InitialConditions=self.InitialConditions[1])
         self.routStore.computeOutFlow()
         n=min(len(self.routStore.Runoff),len(self.channel2.Outflow))
+        self.DirectRunoff=np.array([0]*n,dtype='float')
         for j in range(0,n):
-            self.channel2.Outflow[j]=max(0,self.channel2.Outflow[j]+self.routStore.Leakages[j])
-        self.Q=self.routStore.Runoff[0:n]+self.channel2.Outflow[0:n]
+            self.DirectRunoff[j]=max(0,self.channel2.Outflow[j]+self.routStore.Leakages[j])
+        self.Q=self.routStore.Runoff[0:n]+self.DirectRunoff[0:n]
     def executeRun(self):
         self.computeRunoff()
         self.computeOutFlow()


### PR DESCRIPTION
Se revisaron las clases ProductionStoreGR4J y RoutingStoreGR4J. Se realizaron las correciones correspondientes, incluyendo Leakage en el balance (pérdidas). Luego se revisó la clase GR4J, puesto que la modificación del par WaterExchange no brindaba cambios (insensible). Se verificó que restaba añadirlo a una ecuación. Así se añadió la substracción de Leakage al aporte directo (channel2). Luego se verificaron las ecuaciones y estaban ol. Si persiste algún error o diferencia significativa a la anterior versión, tendré que evaluar nuevamente si no hay errores de rendondeo.  